### PR TITLE
Change from string to boolean

### DIFF
--- a/cabot_alert_slack/models.py
+++ b/cabot_alert_slack/models.py
@@ -93,11 +93,11 @@ class SlackAlert(AlertPlugin):
                 'fields': [{
                     'title': 'status',
                     'value': service.overall_status,
-                    'short': 'false'
+                    'short': False
                     }, {
                     'title': 'old status',
                     'value': service.old_overall_status,
-                    'short': 'false'
+                    'short': False
                     }
                 ],
                 'callback_id': "acknowledge_{}".format(service.id),


### PR DESCRIPTION
This fix allows cabot_alert_slack to be used for notifying Mattermost, which is compatible with Slack webhooks.  Slack allows "false" but [the docs say to use a boolean.](https://api.slack.com/docs/message-attachments)

Current json payload format:
```json
"fields": [
                {
                    "title": "Priority",
                    "value": "High",
                    "short": "false"
                }
            ],
```

New json payload format:
```json
"fields": [
                {
                    "title": "Priority",
                    "value": "High",
                    "short": false
                }
            ],
```