### PR TITLE
Added SLACK_SENDER

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+Version 0.8.4
+-------------
+* Added SLACK_SENDER env variable to allow Slack to show chosen name. (SL)
+
 Version 0.8.3
 -------------
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ CABOT_PLUGINS_ENABLED=cabot_alert_slack==0.6
 SLACK_ALERT_CHANNEL=channel_name_without_hash
 SLACK_WEBHOOK_URL=url_of_your_webhook_integration_from_slack
 SLACK_ICON_URL=http://lorempixel.com/40/40/
+SLACK_SENDER=chosen_name (max 15 chars)
 ```
 
 Add cabot_alert_slack to the installed apps in settings.py

--- a/cabot_alert_slack/models.py
+++ b/cabot_alert_slack/models.py
@@ -68,9 +68,7 @@ class SlackAlert(AlertPlugin):
         channel = '#' + env.get('SLACK_ALERT_CHANNEL')
         url = env.get('SLACK_WEBHOOK_URL')
         icon_url = env.get('SLACK_ICON_URL')
-        sender = env.get('SLACK_SENDER')
-        if sender is None:
-            sender = 'Cabot'
+        sender = env.get('SLACK_SENDER', 'Cabot')
         actions = []
         if env.get('SLACK_INTERACTIVE_MESSAGES', False) and service.overall_status != service.PASSING_STATUS:
             actions.append({

--- a/cabot_alert_slack/models.py
+++ b/cabot_alert_slack/models.py
@@ -61,14 +61,16 @@ class SlackAlert(AlertPlugin):
             'alert': alert,
         })
         message = Template(slack_template).render(c)
-        self._send_slack_alert(message, service, color=color, sender='Cabot')
+        self._send_slack_alert(message, service, color=color)
 
-    def _send_slack_alert(self, message, service, color='good', sender='Cabot'):
+    def _send_slack_alert(self, message, service, color='good'):
 
         channel = '#' + env.get('SLACK_ALERT_CHANNEL')
         url = env.get('SLACK_WEBHOOK_URL')
         icon_url = env.get('SLACK_ICON_URL')
-
+        sender = env.get('SLACK_SENDER')
+        if sender is None:
+            sender = 'Cabot'
         actions = []
         if env.get('SLACK_INTERACTIVE_MESSAGES', False) and service.overall_status != service.PASSING_STATUS:
             actions.append({

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='cabot-alert-slack',
-      version='0.8.3',
+      version='0.8.4',
       description='A slack alert plugin for Cabot by Arachnys',
       author='Luka Blaskovic',
       author_email='lblasc@znode.net',


### PR DESCRIPTION
Added ability to set sender name other than 'Cabot' - this shows in Slack as the origin username 